### PR TITLE
Allow building with camlidl installed in a non standard directory

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -15,10 +15,12 @@ CC = gcc
 OCAML_LIBS = unix lwt lwt.unix str cryptokit parsifal_syntax parsifal_core parsifal_lwt parsifal_crypto \
 	parsifal_net parsifal_formats parsifal_ssl parsifal_kerby parsifal_pgp
 
+CAMLIDL_DIR = `$(OCAMLFIND) query camlidl`
+
 # use the following variables to add extra flags (not guessed by ocamlfind)
 EXTRA_OCAMLOPT_CC_FLAGS =
 # EXTRA_OCAMLOPT_CC_FLAGS = -package parsifal_syntax
-EXTRA_OCAMLOPT_LD_FLAGS = ../kerby/build/krb5_stubs.o ../kerby/build/krb5_functions.o -cclib -lk5crypto -cclib -lcamlidl -cclib -lmylzma -cclib -lmytiano -ccopt -Lbuild/
+EXTRA_OCAMLOPT_LD_FLAGS = ../kerby/build/krb5_stubs.o ../kerby/build/krb5_functions.o -cclib -lk5crypto -ccopt "-L $(CAMLIDL_DIR)" -cclib -lcamlidl -cclib -lmylzma -cclib -lmytiano -ccopt -Lbuild/
 EXTRA_OCAMLC_CC_FLAGS =
 # EXTRA_OCAMLC_CC_FLAGS = -package parsifal_syntax
 EXTRA_OCAMLC_LD_FLAGS =


### PR DESCRIPTION
Allow building with camlidl installed in a non standard directory
